### PR TITLE
Add additional SQL condition for very low admin logic

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1056,7 +1056,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads l\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon p\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(ST_Centroid(l.way), p.way)\n              AND osm_id < 0\n          )\n      )\n    )\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n  ) AS admin_very_low_zoom",
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads l\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon p\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(l.way, p.way)\n              AND osm_id < 0\n          )\n      )\n    )\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n  ) AS admin_very_low_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1321,7 +1321,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon o\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon i\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(ST_Centroid(o.way), i.way)\n              AND osm_id < 0\n          )\n      )\n    )\n    AND way_area > 100*!pixel_width!::real*!pixel_height!::real -- Conditions in the MSS filter this down even more\n  ORDER BY admin_level ASC, way_area DESC\n) AS placenames_large_low_zoom",
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon o\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon i\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(o.way, i.way)\n              AND osm_id < 0\n          )\n      )\n    )\n    AND way_area > 100*!pixel_width!::real*!pixel_height!::real -- Conditions in the MSS filter this down even more\n  ORDER BY admin_level ASC, way_area DESC\n) AS placenames_large_low_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.mml
+++ b/project.mml
@@ -1056,7 +1056,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads l\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon p\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(ST_Centroid(l.way), p.way)\n          )\n      )\n    )\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n  ) AS admin_very_low_zoom",
+        "table": "(SELECT\n    way,\n    admin_level\n  FROM planet_osm_roads l\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon p\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(ST_Centroid(l.way), p.way)\n              AND osm_id < 0\n          )\n      )\n    )\n    AND osm_id < 0\n  ORDER BY admin_level DESC\n  ) AS admin_very_low_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1294,7 +1294,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level = '2'\n    AND name IS NOT NULL\n  ORDER BY admin_level ASC, way_area DESC\n) AS placenames_large_very_low_zoom",
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level = '2'\n    AND name IS NOT NULL\n    AND way_area > 100*!pixel_width!::real*!pixel_height!::real -- Conditions in the MSS filter this down even more\n  ORDER BY admin_level ASC, way_area DESC\n) AS placenames_large_very_low_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1321,7 +1321,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon o\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon i\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(ST_Centroid(o.way), i.way)\n          )\n      )\n    )\n  ORDER BY admin_level ASC, way_area DESC\n  ) AS placenames_large_low_zoom",
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon o\n  WHERE boundary = 'administrative'\n    AND (admin_level IN ('0', '1', '2')\n      OR (admin_level IN ('3', '4')\n        AND EXISTS\n          (SELECT 1\n            FROM planet_osm_polygon i\n            WHERE boundary = 'administrative'\n              AND admin_level = '2'\n              AND way_area > 9e+12\n              AND ST_Within(ST_Centroid(o.way), i.way)\n              AND osm_id < 0\n          )\n      )\n    )\n    AND way_area > 100*!pixel_width!::real*!pixel_height!::real -- Conditions in the MSS filter this down even more\n  ORDER BY admin_level ASC, way_area DESC\n) AS placenames_large_low_zoom",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",
@@ -1348,7 +1348,7 @@
       "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over",
       "Datasource": {
         "extent": "-20037508,-20037508,20037508,20037508",
-        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('2', '4')\n    AND name IS NOT NULL\n  ORDER BY admin_level ASC, way_area DESC\n) AS placenames_large",
+        "table": "(SELECT\n    way,\n    way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,\n    name,\n    ref,\n    admin_level\n  FROM planet_osm_polygon\n  WHERE boundary = 'administrative'\n    AND admin_level IN ('2', '4')\n    AND name IS NOT NULL\n    AND way_area > 100*!pixel_width!::real*!pixel_height!::real -- Conditions in the MSS filter this down even more\n  ORDER BY admin_level ASC, way_area DESC\n) AS placenames_large",
         "geometry_field": "way",
         "type": "postgis",
         "key_field": "",

--- a/project.yaml
+++ b/project.yaml
@@ -1333,6 +1333,7 @@ Layer:
                       AND admin_level = '2'
                       AND way_area > 9e+12
                       AND ST_Within(ST_Centroid(l.way), p.way)
+                      AND osm_id < 0
                   )
               )
             )
@@ -1517,6 +1518,7 @@ Layer:
           WHERE boundary = 'administrative'
             AND admin_level = '2'
             AND name IS NOT NULL
+            AND way_area > 100*!pixel_width!::real*!pixel_height!::real -- Conditions in the MSS filter this down even more
           ORDER BY admin_level ASC, way_area DESC
         ) AS placenames_large_very_low_zoom
     properties:
@@ -1548,11 +1550,13 @@ Layer:
                       AND admin_level = '2'
                       AND way_area > 9e+12
                       AND ST_Within(ST_Centroid(o.way), i.way)
+                      AND osm_id < 0
                   )
               )
             )
+            AND way_area > 100*!pixel_width!::real*!pixel_height!::real -- Conditions in the MSS filter this down even more
           ORDER BY admin_level ASC, way_area DESC
-          ) AS placenames_large_low_zoom
+        ) AS placenames_large_low_zoom
     properties:
       minzoom: 4
       maxzoom: 4
@@ -1575,6 +1579,7 @@ Layer:
           WHERE boundary = 'administrative'
             AND admin_level IN ('2', '4')
             AND name IS NOT NULL
+            AND way_area > 100*!pixel_width!::real*!pixel_height!::real -- Conditions in the MSS filter this down even more
           ORDER BY admin_level ASC, way_area DESC
         ) AS placenames_large
     properties:

--- a/project.yaml
+++ b/project.yaml
@@ -1332,7 +1332,7 @@ Layer:
                     WHERE boundary = 'administrative'
                       AND admin_level = '2'
                       AND way_area > 9e+12
-                      AND ST_Within(ST_Centroid(l.way), p.way)
+                      AND ST_Within(l.way, p.way)
                       AND osm_id < 0
                   )
               )
@@ -1549,7 +1549,7 @@ Layer:
                     WHERE boundary = 'administrative'
                       AND admin_level = '2'
                       AND way_area > 9e+12
-                      AND ST_Within(ST_Centroid(o.way), i.way)
+                      AND ST_Within(o.way, i.way)
                       AND osm_id < 0
                   )
               )


### PR DESCRIPTION
Adding p.way && !bbox! drastically helps query planning for some
reason. Having added !bbox! once, it needs to be added for both
tables.

osm_id < 0 doesn't change much, but would help if there was a
partial index.
